### PR TITLE
Fix function definition and max field lengths for messages

### DIFF
--- a/ocre_api.c
+++ b/ocre_api.c
@@ -110,14 +110,13 @@ void ocre_process_events(void)
     int event_count = 0;
     const int max_events_per_loop = 5;
 
-    char topic_copy[TOPIC_MAX_LEN];
-    char content_type_copy[CONTENT_TYPE_MAX_LEN];
-    uint8_t payload_copy[PAYLOAD_MAX_LEN];
+    char topic_copy[OCRE_MAX_TOPIC_LEN];
+    char content_type_copy[OCRE_MAX_CONTENT_TYPE_LEN];
+    uint8_t payload_copy[OCRE_MAX_PAYLOAD_LEN];
 
     event_data_t event_data;
     while (event_count < max_events_per_loop)
     {
-        uint32_t payload_len = 0;
         int ret = ocre_get_event(
             (uint32_t)&event_data.type,
             (uint32_t)&event_data.id,
@@ -131,7 +130,7 @@ void ocre_process_events(void)
                 break;
         }
 #ifdef OCRE_SDK_LOG
-        printf("Ocre process event retrieved: type=%u, id=%d, port(topic)=%u, state(content)=%u, extra(payload)=%u payload_len=%d\n", event_data.type, event_data.id, event_data.port, event_data.state, event_data.extra, payload_len);
+        printf("Ocre process event retrieved: type=%u, id=%d, port(topic)=%u, state(content)=%u, extra(payload)=%u payload_len=%d\n", event_data.type, event_data.id, event_data.port, event_data.state, event_data.extra, event_data.payload_len);
 #endif
         switch (event_data.type)
         {
@@ -143,15 +142,15 @@ void ocre_process_events(void)
             break;
         case OCRE_RESOURCE_TYPE_MESSAGE:
             // Copy topic
-            strncpy(topic_copy, (const char *)event_data.port, TOPIC_MAX_LEN - 1);
-            topic_copy[TOPIC_MAX_LEN - 1] = '\0';
+            strncpy(topic_copy, (const char *)event_data.port, OCRE_MAX_TOPIC_LEN - 1);
+            topic_copy[OCRE_MAX_TOPIC_LEN - 1] = '\0';
 
             // Copy content_type
-            strncpy(content_type_copy, (const char *)event_data.state, CONTENT_TYPE_MAX_LEN - 1);
-            content_type_copy[CONTENT_TYPE_MAX_LEN - 1] = '\0';
+            strncpy(content_type_copy, (const char *)event_data.state, OCRE_MAX_CONTENT_TYPE_LEN - 1);
+            content_type_copy[OCRE_MAX_CONTENT_TYPE_LEN - 1] = '\0';
 
             // Copy payload
-            uint32_t len = event_data.payload_len > PAYLOAD_MAX_LEN ? PAYLOAD_MAX_LEN : event_data.payload_len;
+            uint32_t len = event_data.payload_len > OCRE_MAX_PAYLOAD_LEN ? OCRE_MAX_PAYLOAD_LEN : event_data.payload_len;
             memcpy(payload_copy, (const uint8_t *)event_data.extra, len);
 
             if (ocre_messaging_free_module_event_data(event_data.port, event_data.state, event_data.extra) != OCRE_SUCCESS)

--- a/ocre_api.h
+++ b/ocre_api.h
@@ -46,6 +46,7 @@ extern "C"
 #define OCRE_MAX_SENSORS 32
 #define OCRE_MAX_CALLBACKS 64
 #define OCRE_MAX_TOPIC_LEN 128
+#define OCRE_MAX_CONTENT_TYPE_LEN 128
 #define OCRE_MAX_PAYLOAD_LEN 1024
 #define CONFIG_MAX_SENSOR_NAME_LENGTH 125
 #define OCRE_API_POSIX_BUF_SIZE 65
@@ -366,10 +367,6 @@ extern "C"
         void *payload;        /**< Payload of the request */
         uint32_t payload_len; /**< Length in bytes of the payload */
     } ocre_msg_t;
-
-#define TOPIC_MAX_LEN 128
-#define CONTENT_TYPE_MAX_LEN 64
-#define PAYLOAD_MAX_LEN 512
 
     /**
      * @brief Initialize OCRE Messaging System

--- a/ocre_api.h
+++ b/ocre_api.h
@@ -486,10 +486,9 @@ extern "C"
     /**
      * @brief Get the handle of a sensor by name
      * @param sensor_name Name of the sensor
-     * @param handle Pointer to store the sensor handle
      * @return OCRE_SUCCESS on success, negative error code on failure
      */
-    int ocre_sensors_get_handle_by_name(const char *sensor_name, ocre_sensor_handle_t handle);
+    int ocre_sensors_get_handle_by_name(const char *sensor_name);   //, ocre_sensor_handle_t handle);
 
     /**
      * @brief Open a sensor by name


### PR DESCRIPTION
- A message function had an incorrect parameter which needed to be removed
- There were duplicated #defines for the max length of ocre message fields with different values than intended. These have been consolidated and corrected.

I did take a best guess at the max length for the content type, please adjust if desired.